### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 ###########################################
 
-ShiftOut KEYWORD1
+ShiftOut	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-begin KEYWORD2
-digitalWrite KEYWORD2
-actualValue KEYWORD2
-low KEYWORD2
-high KEYWORD2
-toggle KEYWORD2
-lowAll KEYWORD2
-highAll KEYWORD2
-toggleAll KEYWORD2
-test KEYWORD2
+begin	KEYWORD2
+digitalWrite	KEYWORD2
+actualValue	KEYWORD2
+low	KEYWORD2
+high	KEYWORD2
+toggle	KEYWORD2
+lowAll	KEYWORD2
+highAll	KEYWORD2
+toggleAll	KEYWORD2
+test	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords